### PR TITLE
Add Cabal files for stack v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work
 *.cabal
+stack.yaml.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .stack-work
-*.cabal
 stack.yaml.lock

--- a/mix-json-logger/mix-json-logger.cabal
+++ b/mix-json-logger/mix-json-logger.cabal
@@ -1,0 +1,36 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: a253cc37b1b5c9c5cb239eb91e957c0dfc2f576cf42bffa010736e2a31e09660
+
+name:           mix-json-logger
+version:        0.1.0
+author:         MATSUBARA Nobutada
+maintainer:     t12307043@gunma-u.ac.jp
+copyright:      2019 MATSUBARA Nobutada
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+library
+  exposed-modules:
+      Mix.Plugin.Logger.JSON
+  other-modules:
+      Paths_mix_json_logger
+  hs-source-dirs:
+      src
+  default-extensions: NoImplicitPrelude ConstraintKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving OverloadedStrings PolyKinds RankNTypes StandaloneDeriving TypeFamilies TypeSynonymInstances
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  build-depends:
+      aeson
+    , base >=4.7 && <5
+    , extensible
+    , mix
+    , rio >=0.1.1.0
+  default-language: Haskell2010

--- a/mix-plugin-drone/mix-plugin-drone.cabal
+++ b/mix-plugin-drone/mix-plugin-drone.cabal
@@ -1,0 +1,38 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: df106535776b5e293868a06bb01de78b332456c34066f80b7eed53039854d82e
+
+name:           mix-plugin-drone
+version:        0.1.1
+author:         MATSUBARA Nobutada
+maintainer:     t12307043@gunma-u.ac.jp
+copyright:      2019 MATSUBARA Nobutada
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+library
+  exposed-modules:
+      Mix.Plugin.Drone
+  other-modules:
+      Paths_mix_plugin_drone
+  hs-source-dirs:
+      src
+  default-extensions: NoImplicitPrelude ConstraintKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving OverloadedStrings PolyKinds RankNTypes StandaloneDeriving TypeFamilies TypeSynonymInstances
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  build-depends:
+      base >=4.7 && <5
+    , data-default-class
+    , drone
+    , extensible
+    , mix
+    , req
+    , rio >=0.1.1.0
+  default-language: Haskell2010

--- a/mix-plugin-github/mix-plugin-github.cabal
+++ b/mix-plugin-github/mix-plugin-github.cabal
@@ -1,0 +1,36 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 878b048633e3bf3e496aea398829290424667dafd510268bb112d9af9f33ddbf
+
+name:           mix-plugin-github
+version:        0.1.1
+author:         MATSUBARA Nobutada
+maintainer:     t12307043@gunma-u.ac.jp
+copyright:      2019 MATSUBARA Nobutada
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+library
+  exposed-modules:
+      Mix.Plugin.GitHub
+  other-modules:
+      Paths_mix_plugin_github
+  hs-source-dirs:
+      src
+  default-extensions: NoImplicitPrelude ConstraintKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving OverloadedStrings PolyKinds RankNTypes StandaloneDeriving TypeFamilies TypeSynonymInstances
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  build-depends:
+      base >=4.7 && <5
+    , extensible
+    , github
+    , mix
+    , rio >=0.1.1.0
+  default-language: Haskell2010

--- a/mix-plugin-shell/mix-plugin-shell.cabal
+++ b/mix-plugin-shell/mix-plugin-shell.cabal
@@ -1,0 +1,36 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 52710f54e5e4cedd7d954d206c7553c475cf986874af642f91540fc2979c4d78
+
+name:           mix-plugin-shell
+version:        0.1.0
+author:         MATSUBARA Nobutada
+maintainer:     t12307043@gunma-u.ac.jp
+copyright:      2019 MATSUBARA Nobutada
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+library
+  exposed-modules:
+      Mix.Plugin.Shell
+  other-modules:
+      Paths_mix_plugin_shell
+  hs-source-dirs:
+      src
+  default-extensions: NoImplicitPrelude ConstraintKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving OverloadedStrings PolyKinds RankNTypes StandaloneDeriving TypeFamilies TypeSynonymInstances
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  build-depends:
+      base >=4.7 && <5
+    , extensible
+    , mix
+    , rio >=0.1.1.0
+    , shelly
+  default-language: Haskell2010

--- a/mix/mix.cabal
+++ b/mix/mix.cabal
@@ -1,0 +1,39 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: eadfa02a29a0fae483c07f1a602c786b433628ee7795b72ba484991dbe30ecc1
+
+name:           mix
+version:        0.1.1
+author:         MATSUBARA Nobutada
+maintainer:     t12307043@gunma-u.ac.jp
+copyright:      2019 MATSUBARA Nobutada
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+library
+  exposed-modules:
+      Mix
+      Mix.Plugin
+      Mix.Plugin.Config
+      Mix.Plugin.Logger
+      Mix.Run
+  other-modules:
+      Paths_mix
+  hs-source-dirs:
+      src
+  default-extensions: NoImplicitPrelude ConstraintKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving OverloadedStrings PolyKinds RankNTypes StandaloneDeriving TypeFamilies TypeSynonymInstances
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  build-depends:
+      base >=4.7 && <5
+    , extensible
+    , mtl
+    , rio >=0.1.1.0
+  default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,6 +8,5 @@ packages:
 extra-deps:
 - extensible-0.5
 - github-0.21
-- shh-0.3.1.3
 - github: matsubara0507/drone-haskell
   commit: aa6f5152dd9ea72cb48a32bdc58c91de2bdc21a9


### PR DESCRIPTION
if use mix packages using stack-2.1.1 as follows config:

```yaml
extra-deps:
- github: matsubara0507/mix.hs
  commit: 45a0033b4b479a4e95687a6ceb3381dfc5e91d8d
  subdirs:
  - mix
  - mix-json-logger
```

error occurred...

```
$ stack build
Cabal file info not found for extensible-0.5, updating
Selected mirror https://s3.amazonaws.com/hackage.fpcomplete.com/
Downloading root
Selected mirror https://s3.amazonaws.com/hackage.fpcomplete.com/
Downloading timestamp
Downloading snapshot
Downloading mirrors
Cannot update index (no local copy)
Downloading index
Updated package index downloaded
Calculating hashes to check for hackage-security rebases or filesystem changes
No old cache found, populating cache from scratch
Populating cache from file size 606624768, hash 29db327ba3cecd02d72a043ab9d88aef73f883c7a42ea8e929245c4778463a14
Populating package index cache ...
Package index cache populated
Invalid value for "defaults"! File /private/var/folders/cp/j_f70sks34dcqsrqjgdll5jskt59rw/T/hpack-pkg-dir86858/../mix-base.yaml does not exist!
```

`local` function of `defaults` doesn't work in stack-2.1.1.
So, I did `git commit` each cabal files.
